### PR TITLE
Fix in loading external amplitudes for magnitude calculation

### DIFF
--- a/filterbanks/.gitignore
+++ b/filterbanks/.gitignore
@@ -1,0 +1,5 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore
+

--- a/mqs_reports/event.py
+++ b/mqs_reports/event.py
@@ -611,7 +611,10 @@ class Event:
 
         if self.name in mag_exc['events_A0']:
             mag_type = "MFB"
-            A0_fix = mag_exc['events_A0'][self.name]['value']
+            if mag_exc['events_A0'][self.name]['kind'] == 'manual':
+                A0_fix = mag_exc['events_A0'][self.name]['value']
+            else:
+                A0_fix = None
         else:
             A0_fix = None
 


### PR DESCRIPTION
 - for VF events without external amplitude, where A0 fit was to be used, a random value was selected, resulting in magnitudes > 9.