### PR TITLE
[setup.py] fix matplotlib version to 3.6.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,5 @@ setup(name='mqs_reports',
       author_email='staehler@erdw.ethz.ch',
       license='None',
       packages=find_packages(),
-      install_requires=['obspy', 'plotly', 'lxml', 'numpy', 'matplotlib',
-                        'tqdm', 'scipy'])
+      install_requires=['obspy', 'plotly', 'lxml', 'numpy', 'tqdm', 
+                        'scipy', 'matplotlib==3.6.3'])


### PR DESCRIPTION
Versions > 3.6.3 break with the error: "ValueError: keyword grid_b is not recognized"

This is due to a deprecation: see https://github.com/matplotlib/matplotlib/issues/25267